### PR TITLE
Fix admin panel / brand nav links 404ing on GitHub Pages

### DIFF
--- a/src/components/naviagtion.jsx
+++ b/src/components/naviagtion.jsx
@@ -1,15 +1,13 @@
 import React, { Component } from "react";
 import { Navbar, Form, Button } from "react-bootstrap";
+import { Link } from "react-router-dom";
 
 class Navigation extends Component {
   render() {
     return (
       <React.Fragment>
         <Navbar sticky="top" bg="light" expand="lg">
-          <Navbar.Brand
-            // href={`https://koalabzium.github.io/MamaWebsiteFront/books`}
-            href={`/`}
-          >
+          <Navbar.Brand as={Link} to="/">
             Biblioteka
           </Navbar.Brand>
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
@@ -23,7 +21,7 @@ class Navigation extends Component {
               </Nav.Link>
             </Nav> */}
             <Form inline>
-              <Button variant="outline-dark" href={`/admin`}>
+              <Button as={Link} variant="outline-dark" to="/admin">
                 Panel adminki
               </Button>
             </Form>


### PR DESCRIPTION
Both used a plain <a href> for full-page browser navigation instead of react-router's Link. With HashRouter, every real client-side route lives in the URL hash (#/admin, #/books, ...) - a raw href to "/admin" or "admin" produces a real path navigation to a URL GitHub Pages has no static file for, so it 404s regardless of the exact href value.

Switched both to react-bootstrap's `as={Link}` polymorphic prop so they render as react-router Links (producing the correct #/admin, #/ hrefs and navigating client-side) while keeping their existing Bootstrap styling.

Verified: built and served locally under the same /MamaWebsiteFront path prefix GitHub Pages uses; clicking "Panel adminki" now lands on #/admin and renders the login form instead of 404ing.


Claude-Session: https://claude.ai/code/session_018G2XFGTEpJ2rDjHJikipNQ