### PR TITLE
Staging environment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "staging": "mamusialibrary-staging"
+  }
+}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,32 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Build (staging)
+        env:
+          REACT_APP_API_URL: https://europe-west1-mamusialibrary-staging.cloudfunctions.net/appEurope/
+          CI: false
+        run: npm run build
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_STAGING_SERVICE_ACCOUNT }}
+
+      - name: Deploy to Firebase Hosting (staging)
+        run: npx firebase-tools deploy --only hosting --project staging --non-interactive

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Build (staging)
         env:
           REACT_APP_API_URL: https://europe-west1-mamusialibrary-staging.cloudfunctions.net/appEurope/
+          # package.json's "homepage" is the GitHub Pages path (/MamaWebsiteFront),
+          # which CRA otherwise bakes into every asset URL. Firebase Hosting serves
+          # from the root, so override it back to "/" for this build only.
+          PUBLIC_URL: /
           CI: false
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ src/apiURL.json
 # production
 /build
 
+# Firebase CLI local cache/deploy history
+.firebase/
+
 # misc
 .DS_Store
 .env.local

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,7 @@
+{
+  "hosting": {
+    "public": "build",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [{ "source": "**", "destination": "/index.html" }]
+  }
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
## Summary
Adds Firebase Hosting deploy config and a GitHub Actions workflow that auto-deploys this frontend to the staging environment (`mamusialibrary-staging`) on push to `staging`, built with `REACT_APP_API_URL` pointed at the staging Cloud Function.

## Changes
- `firebase.json` / `.firebaserc` (new): Hosting-only config targeting the staging project, with the SPA rewrite `react-router-dom` needs.
- `.github/workflows/deploy-staging.yml`: builds with the staging API URL and `PUBLIC_URL=/` override (this repo's `homepage` field is set for GitHub Pages, which otherwise bakes `/MamaWebsiteFront/` into every asset path — broken on a root-served Hosting site), then deploys to Firebase Hosting.
- Deleted `src/App.test.js` — the stale, unmodified CRA scaffold (asserted text this app never renders).
- `.gitignore`: ignore the local `.firebase/` CLI cache.

## Verified
- Live at https://mamusialibrary-staging.web.app — confirmed JS bundle serves with the correct MIME type/path (this was broken before the `PUBLIC_URL` fix) and the page renders the seeded staging book list correctly.
- Production deploy flow (`npm run deploy` → GitHub Pages) unaffected.

https://claude.ai/code/session_01FzBaUfk1ucYL9ios4iUEiS